### PR TITLE
Switch to clang compiler

### DIFF
--- a/jni/Application.mk
+++ b/jni/Application.mk
@@ -21,3 +21,4 @@
 
 APP_MODULES := libgtest
 APP_STL := gnustl_static
+NDK_TOOLCHAIN_VERSION := clang


### PR DESCRIPTION
According to [NDK Changelog](https://android.googlesource.com/platform/ndk.git/+/master/CHANGELOG.md), gcc compiler is now deprecated in favor of clang. Googletest compiles fine with clang as well, and this PR switch the compiler to clang.
